### PR TITLE
Update express version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/UKHomeOfficeForms/hof-behaviour-session#readme",
   "dependencies": {
-    "express": "^4.14.1",
+    "express": "^4.15.2",
     "lodash": "^4.17.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Snyk is complaining about a vuln in qs included as a transitive dependency of express@4.14